### PR TITLE
Doc Downloads: use freeimage-devel instead of libfreeimage-devel

### DIFF
--- a/doxygen/md/Downloads.md
+++ b/doxygen/md/Downloads.md
@@ -54,7 +54,7 @@ If your distribution is based on Red Hat, all tools and almost all dependencies 
 
 ```
 $ sudo dnf update
-$ sudo dnf install @development-tools make automake gcc gcc-c++ meson libwayland-server wayland-devel libinput-devel libevdev-devel libudev-devel mesa-libEGL-devel libxkbcommon-devel libXcursor-devel pixman-devel libdrm-devel libgbm-devel libseat-devel libfreeimage-devel fontconfig-devel freetype-devel libicu-devel
+$ sudo dnf install @development-tools make automake gcc gcc-c++ meson libwayland-server wayland-devel libinput-devel libevdev-devel libudev-devel mesa-libEGL-devel libxkbcommon-devel libXcursor-devel pixman-devel libdrm-devel libgbm-devel libseat-devel freeimage-devel fontconfig-devel freetype-devel libicu-devel
 ```
 
 To install SRM, follow the instructions provided [here](https://cuarzosoftware.github.io/SRM/md_md__downloads.html).


### PR DESCRIPTION
libfreeimage-devel does not exist on Fedora, freeimage-devel seems to be the right name https://pkgs.org/download/freeimage-devel.

Cool project! Also a note: I was trying it in a virt-manager VM and to my surprise the examples actually ran but cursor input (movement ok but not clicks) was not working however. Keyboard input was. But I assume a VM is not the supposed way to run this right now (just the easiest to run it for me atm as fedora was documented well)