### PR TITLE
mention list of projects on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Louvre is a high-performance C++ library designed for building Wayland composito
 * [🕹️ Examples](https://cuarzosoftware.github.io/Louvre/md_md__examples.html)
 * [📦 Downloads](https://cuarzosoftware.github.io/Louvre/md_md__downloads.html)
 * [💬 Contact](https://cuarzosoftware.github.io/Louvre/md_md__contact.html)
-* [🖼️ Gallery](https://github.com/CuarzoSoftware/Louvre/blob/gallery/README.md)
+* [🖼️ Projects Using Louvre](https://github.com/CuarzoSoftware/Louvre/blob/gallery/README.md)
 
 Creating a Wayland compositor can be a daunting undertaking, often spanning months or even years of dedication. This challenging task involves mastering Linux input and graphic APIs, managing graphic buffers, and meticulously implementing numerous Wayland protocols and their respective interfaces.
 


### PR DESCRIPTION
using the word "Gallery" when linking to a list of projects makes it seem like it is just a bunch of picture, A person looking for a list of projects won't click on the link.