### PR TITLE
remove SRM include path prefix

### DIFF
--- a/src/backends/graphic/DRM/LGraphicBackendDRM.cpp
+++ b/src/backends/graphic/DRM/LGraphicBackendDRM.cpp
@@ -29,14 +29,14 @@
 #include <LTime.h>
 #include <LGammaTable.h>
 
-#include <SRM/SRMCore.h>
-#include <SRM/SRMDevice.h>
-#include <SRM/SRMConnector.h>
-#include <SRM/SRMConnectorMode.h>
-#include <SRM/SRMBuffer.h>
-#include <SRM/SRMListener.h>
-#include <SRM/SRMList.h>
-#include <SRM/SRMFormat.h>
+#include <SRMCore.h>
+#include <SRMDevice.h>
+#include <SRMConnector.h>
+#include <SRMConnectorMode.h>
+#include <SRMBuffer.h>
+#include <SRMListener.h>
+#include <SRMList.h>
+#include <SRMFormat.h>
 
 using namespace Louvre;
 

--- a/src/backends/graphic/Wayland/LGraphicBackendWayland.cpp
+++ b/src/backends/graphic/Wayland/LGraphicBackendWayland.cpp
@@ -7,7 +7,7 @@
 #include <private/LFactory.h>
 
 #include <LOutputMode.h>
-#include <SRM/SRMFormat.h>
+#include <SRMFormat.h>
 #include <LCursor.h>
 #include <LTime.h>
 #include <LLog.h>


### PR DESCRIPTION
- fixes build with SRM as a submodule
- the /usr/include/SRM/ include files do not expect the SRM/ include path, for example SRMCore.h has `#include <SRMTypes.h>`.