### PR TITLE
SUPER+click/drag for moving/resizing windows

### DIFF
--- a/src/examples/louvre-views/src/Global.cpp
+++ b/src/examples/louvre-views/src/Global.cpp
@@ -163,6 +163,7 @@ void G::loadCursors()
     xCursors.top_side = LXCursor::load("top_side");
     xCursors.right_side = LXCursor::load("right_side");
     xCursors.bottom_side = LXCursor::load("bottom_side");
+    xCursors.move = LXCursor::load("move");
 }
 
 G::Cursors &G::cursors()

--- a/src/examples/louvre-views/src/Global.h
+++ b/src/examples/louvre-views/src/Global.h
@@ -149,6 +149,7 @@ public:
         LXCursor *top_side = nullptr;
         LXCursor *right_side = nullptr;
         LXCursor *bottom_side = nullptr;
+        LXCursor *move = nullptr;
     };
 
     struct ToplevelRegions

--- a/src/examples/louvre-views/src/Keyboard.cpp
+++ b/src/examples/louvre-views/src/Keyboard.cpp
@@ -165,20 +165,19 @@ void Keyboard::keyEvent(const LKeyboardKeyEvent &event)
 
             case KEY_PAGEDOWN:
             {
-                Surface *s = (Surface*)focus();
-                if (s && s->tl()) s->tl()->setMinimizedRequest();
+                if (seat()->activeToplevel())
+                    seat()->activeToplevel()->setMinimizedRequest();
                 return;
             }
 
             case KEY_PAGEUP:
             {
-                Surface *s = (Surface*)focus();
-                if (s && s->tl()) {
-                    if (s->tl()->maximized()) {
-                        s->tl()->unsetMaximizedRequest();
-                    } else {
-                        s->tl()->setMaximizedRequest();
-                    }
+                if (seat()->activeToplevel())
+                {
+                    if (seat()->activeToplevel()->maximized())
+                        seat()->activeToplevel()->unsetMaximizedRequest();
+                    else
+                        seat()->activeToplevel()->setMaximizedRequest();
                 }
                 return;
             }

--- a/src/examples/louvre-views/src/Keyboard.cpp
+++ b/src/examples/louvre-views/src/Keyboard.cpp
@@ -12,6 +12,8 @@
 #include "LLayerRole.h"
 #include "Output.h"
 #include "Topbar.h"
+#include "Surface.h"
+#include "Toplevel.h"
 #include "App.h"
 #include "Client.h"
 #include "Workspace.h"
@@ -160,6 +162,26 @@ void Keyboard::keyEvent(const LKeyboardKeyEvent &event)
                     while (!client->foreignToplevelManagerGlobals().empty())
                         client->foreignToplevelManagerGlobals().back()->finished();
                 break;
+
+            case KEY_PAGEDOWN:
+            {
+                Surface *s = (Surface*)focus();
+                if (s && s->tl()) s->tl()->setMinimizedRequest();
+                return;
+            }
+
+            case KEY_PAGEUP:
+            {
+                Surface *s = (Surface*)focus();
+                if (s && s->tl()) {
+                    if (s->tl()->maximized()) {
+                        s->tl()->unsetMaximizedRequest();
+                    } else {
+                        s->tl()->setMaximizedRequest();
+                    }
+                }
+                return;
+            }
 
             default:
                 break;

--- a/src/examples/louvre-views/src/Pointer.cpp
+++ b/src/examples/louvre-views/src/Pointer.cpp
@@ -80,34 +80,29 @@ void Pointer::pointerMoveEvent(const LPointerMoveEvent &event)
         cursor()->setCursor(static_cast<LSurfaceView*>(G::scene()->pointerFocus().back())->surface()->client()->lastCursorRequest());
 }
 
-bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event) {
-    if (event.state() != LPointerButtonEvent::Pressed) return false;
-    if (!seat()->keyboard()->isKeyCodePressed(KEY_LEFTMETA)) return false;
-    if (!(event.button() == LPointerButtonEvent::Left ||
-          event.button() == LPointerButtonEvent::Right)) return false;
+bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event)
+{
+    if (!focus()
+        || event.state() != LPointerButtonEvent::Pressed
+        || !seat()->keyboard()->isKeyCodePressed(KEY_LEFTMETA)
+        || !(event.button() == LPointerButtonEvent::Left || event.button() == LPointerButtonEvent::Right))
+        return false;
 
-    LPointF mpos { cursor()->pos() };
+    Toplevel *toplevel { focus()->toplevel() ?
+        static_cast<Toplevel*>(focus()->toplevel()) :
+        static_cast<Surface*>(focus())->closestToplevelParent() };
 
-    // XXX: I have the feeling there's a simpler way to find the Toplevel
-    // object, but this works.
-    LView *view { G::scene()->viewAt(mpos, LView::UndefinedType, LScene::InputFilter::Pointer) };
-    Toplevel *toplevel { nullptr };
-    if (view && view->type() == LView::SurfaceType) {
-        Surface *surface = dynamic_cast<Surface*>( static_cast<LSurfaceView*>(view)->surface() );
-        while (surface) {
-            if ((toplevel = surface->tl())) break;
-            surface = (Surface*)surface->parent();
-            if (surface && surface->views().size() > 0)
-                view = surface->views()[0];
-        }
-    }
-    if (!toplevel) return false;
+    if (!toplevel || toplevel->fullscreen() || toplevel->resizeSession().isActive() || toplevel->moveSession().isActive())
+        return false;
 
+    const LPointF mpos { cursor()->pos() };
+    LView *view { toplevel->surf()->getView() };
     LBitset<LEdge> anchor { 0 };
     LXCursor *cursor { G::cursors().move };
 
     // Meta + Right Click to resize window
-    if (event.button() == LPointerButtonEvent::Right) {
+    if (event.button() == LPointerButtonEvent::Right)
+    {
         LPointF vpos { view->pos() };
         LSizeF vsz { view->size() };
 
@@ -117,84 +112,80 @@ bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event) {
             anchor = LEdgeTop | LEdgeLeft;
             cursor = G::cursors().top_left_corner;
         }
-        if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
         {
             anchor = LEdgeTop;
             cursor = G::cursors().top_side;
         }
-        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
         {
             anchor = LEdgeTop | LEdgeRight;
             cursor = G::cursors().top_right_corner;
         }
-        if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
         {
             anchor = LEdgeLeft;
             cursor = G::cursors().left_side;
         }
-        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
         {
             anchor = LEdgeRight;
             cursor = G::cursors().right_side;
         }
-        if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
         {
             anchor = LEdgeBottom | LEdgeLeft;
             cursor = G::cursors().bottom_left_corner;
         }
-        if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
         {
             anchor = LEdgeBottom;
             cursor = G::cursors().bottom_side;
         }
-        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
         {
             anchor = LEdgeBottom | LEdgeRight;
             cursor = G::cursors().bottom_right_corner;
         }
     }
 
-    if (cursor) {
-        G::compositor()->cursor()->setTextureB(cursor->texture(), cursor->hotspotB());
-        this->cursorOwner = view;
-    }
+    Louvre::cursor()->setCursor(cursor);
+    cursorOwner = view;
 
-    if (anchor) {
+    if (anchor)
         toplevel->startResizeRequest(event, anchor);
-    } else {
+    else
         toplevel->startMoveRequest(event);
-    }
 
     return true;
 }
 
 void Pointer::pointerButtonEvent(const LPointerButtonEvent &event)
 {
-    if (maybeMoveOrResize(event)) {
-        this->isDragging = true;
-        return;
-    }
+    if (maybeMoveOrResize(event))
+        G::scene()->handlePointerButtonEvent(event, 0);
+    else
+        G::scene()->handlePointerButtonEvent(event);
 
-    if (event.state() == LPointerButtonEvent::Released)
+    if (event.state() == LPointerButtonEvent::Released
+        && seat()->toplevelResizeSessions().empty()
+        && seat()->toplevelMoveSessions().empty())
     {
-        if (this->isDragging) {
-            this->isDragging = false;
-            G::compositor()->cursor()->useDefault();
-        }
+        G::compositor()->cursor()->useDefault();
         G::enableDocks(true);
         G::compositor()->updatePointerBeforePaint = true;
     }
 
-    G::scene()->handlePointerButtonEvent(event);
-
-    if (G::compositor()->wofi && G::compositor()->wofi->client && G::compositor()->wofi && !G::scene()->pointerFocus().empty() && G::scene()->pointerFocus().front()->userData() == WallpaperType)
+    if (G::compositor()->wofi && G::compositor()->wofi->client
+        && G::compositor()->wofi && !G::scene()->pointerFocus().empty()
+        && G::scene()->pointerFocus().front()->userData() == WallpaperType)
         G::compositor()->wofi->client->destroyLater();
 }
 

--- a/src/examples/louvre-views/src/Pointer.cpp
+++ b/src/examples/louvre-views/src/Pointer.cpp
@@ -166,7 +166,7 @@ void Pointer::pointerButtonEvent(const LPointerButtonEvent &event)
         return;
     }
 
-    if (event.button() == LPointerButtonEvent::Left && event.state() == LPointerButtonEvent::Released)
+    if (event.state() == LPointerButtonEvent::Released)
     {
         G::enableDocks(true);
         G::compositor()->updatePointerBeforePaint = true;

--- a/src/examples/louvre-views/src/Pointer.cpp
+++ b/src/examples/louvre-views/src/Pointer.cpp
@@ -19,6 +19,9 @@
 #include "Global.h"
 #include "Pointer.h"
 #include "Compositor.h"
+#include "Surface.h"
+#include "Toplevel.h"
+#include "ToplevelView.h"
 #include "src/Client.h"
 
 Pointer::Pointer(const void *params) : LPointer(params)
@@ -77,8 +80,86 @@ void Pointer::pointerMoveEvent(const LPointerMoveEvent &event)
         cursor()->setCursor(static_cast<LSurfaceView*>(G::scene()->pointerFocus().back())->surface()->client()->lastCursorRequest());
 }
 
+bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event) {
+    if (event.state() != LPointerButtonEvent::Pressed) return false;
+    if (!seat()->keyboard()->isKeyCodePressed(KEY_LEFTMETA)) return false;
+
+    LPointF mpos { cursor()->pos() };
+    LView *view { G::scene()->viewAt(mpos, LView::UndefinedType, LScene::InputFilter::Pointer) };
+    Toplevel *toplevel { nullptr };
+
+    if (view && view->type() == LView::SurfaceType) {
+        Surface *surface = dynamic_cast<Surface*>( static_cast<LSurfaceView*>(view)->surface() );
+        if (surface) toplevel = surface->tl();
+    }
+
+    if (!toplevel) return false;
+
+    // Meta + Left Click to move window
+    if (event.button() == LPointerButtonEvent::Left) {
+        toplevel->startMoveRequest(event);
+        return true;
+    }
+
+    // Meta + Right Click to resize window
+    if (event.button() == LPointerButtonEvent::Right) {
+        LPointF vpos { view->pos() };
+        LSizeF vsz { view->size() };
+        LBitset<LEdge> anchor;
+
+        if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
+            anchor = LEdgeTop | LEdgeLeft;
+
+        if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
+            anchor = LEdgeTop;
+
+        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
+            anchor = LEdgeTop | LEdgeRight;
+
+        if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
+            anchor = LEdgeLeft;
+
+        if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
+            anchor = 0;
+
+        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
+            anchor = LEdgeRight;
+
+        if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+            anchor = LEdgeBottom | LEdgeLeft;
+
+        if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+            anchor = LEdgeBottom;
+
+        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+            anchor = LEdgeBottom | LEdgeRight;
+
+        if (anchor) {
+            toplevel->startResizeRequest(LPointerButtonEvent(), anchor);
+        } else {
+            toplevel->startMoveRequest(event);
+        }
+        return true;
+    }
+
+    return false;
+}
+
 void Pointer::pointerButtonEvent(const LPointerButtonEvent &event)
 {
+    if (maybeMoveOrResize(event)) {
+        return;
+    }
+
     if (event.button() == LPointerButtonEvent::Left && event.state() == LPointerButtonEvent::Released)
     {
         G::enableDocks(true);

--- a/src/examples/louvre-views/src/Pointer.cpp
+++ b/src/examples/louvre-views/src/Pointer.cpp
@@ -85,14 +85,20 @@ bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event) {
     if (!seat()->keyboard()->isKeyCodePressed(KEY_LEFTMETA)) return false;
 
     LPointF mpos { cursor()->pos() };
+
+    // XXX: I have the feeling there's a simpler way to find the Toplevel
+    // object, but this works.
     LView *view { G::scene()->viewAt(mpos, LView::UndefinedType, LScene::InputFilter::Pointer) };
     Toplevel *toplevel { nullptr };
-
     if (view && view->type() == LView::SurfaceType) {
         Surface *surface = dynamic_cast<Surface*>( static_cast<LSurfaceView*>(view)->surface() );
-        if (surface) toplevel = surface->tl();
+        while (surface) {
+            if ((toplevel = surface->tl())) break;
+            surface = (Surface*)surface->parent();
+            if (surface && surface->views().size() > 0)
+                view = surface->views()[0];
+        }
     }
-
     if (!toplevel) return false;
 
     // Meta + Left Click to move window

--- a/src/examples/louvre-views/src/Pointer.cpp
+++ b/src/examples/louvre-views/src/Pointer.cpp
@@ -150,7 +150,7 @@ bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event) {
             anchor = LEdgeBottom | LEdgeRight;
 
         if (anchor) {
-            toplevel->startResizeRequest(LPointerButtonEvent(), anchor);
+            toplevel->startResizeRequest(event, anchor);
         } else {
             toplevel->startMoveRequest(event);
         }

--- a/src/examples/louvre-views/src/Pointer.cpp
+++ b/src/examples/louvre-views/src/Pointer.cpp
@@ -164,6 +164,10 @@ bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event)
     else
         toplevel->startMoveRequest(event);
 
+    toplevel->configureState(toplevel->pendingConfiguration().state | LToplevelRole::Activated);
+    toplevel->surface()->raise();
+    seat()->dismissPopups();
+
     return true;
 }
 

--- a/src/examples/louvre-views/src/Pointer.h
+++ b/src/examples/louvre-views/src/Pointer.h
@@ -2,6 +2,7 @@
 #define POINTER_H
 
 #include <LPointer.h>
+#include <LWeak.h>
 
 using namespace Louvre;
 
@@ -14,9 +15,7 @@ public:
     void pointerScrollEvent(const LPointerScrollEvent &event) override;
     void setCursorRequest(const LClientCursor &clientCursor) override;
     bool maybeMoveOrResize(const LPointerButtonEvent &event);
-
-    LView *cursorOwner { nullptr };
-    bool isDragging { false };
+    LWeak<LView> cursorOwner;
 };
 
 #endif // POINTER_H

--- a/src/examples/louvre-views/src/Pointer.h
+++ b/src/examples/louvre-views/src/Pointer.h
@@ -13,6 +13,7 @@ public:
     void pointerButtonEvent(const LPointerButtonEvent &event) override;
     void pointerScrollEvent(const LPointerScrollEvent &event) override;
     void setCursorRequest(const LClientCursor &clientCursor) override;
+    bool maybeMoveOrResize(const LPointerButtonEvent &event);
     LView *cursorOwner { nullptr };
 };
 

--- a/src/examples/louvre-views/src/Pointer.h
+++ b/src/examples/louvre-views/src/Pointer.h
@@ -14,7 +14,9 @@ public:
     void pointerScrollEvent(const LPointerScrollEvent &event) override;
     void setCursorRequest(const LClientCursor &clientCursor) override;
     bool maybeMoveOrResize(const LPointerButtonEvent &event);
+
     LView *cursorOwner { nullptr };
+    bool isDragging { false };
 };
 
 #endif // POINTER_H

--- a/src/examples/louvre-views/src/Surface.cpp
+++ b/src/examples/louvre-views/src/Surface.cpp
@@ -105,6 +105,20 @@ Surface *Surface::searchSessionLockParent(Surface *parent)
     return nullptr;
 }
 
+Toplevel *Surface::closestToplevelParent() const noexcept
+{
+    const LSurface *surface { this };
+
+    while (surface->parent())
+    {
+        if (surface->parent()->toplevel())
+            return static_cast<class Toplevel*>(surface->parent()->toplevel());
+        surface = surface->parent();
+    }
+
+    return nullptr;
+}
+
 LView *Surface::getView() const
 {
     if (tl() && tl()->decoratedView)

--- a/src/examples/louvre-views/src/Surface.h
+++ b/src/examples/louvre-views/src/Surface.h
@@ -23,6 +23,7 @@ public:
     class Toplevel *tl() const {return (class Toplevel*)toplevel();}
 
     static class Surface *searchSessionLockParent(Surface *parent);
+    class Toplevel *closestToplevelParent() const noexcept;
 
     LView *getView() const;
 

--- a/src/examples/louvre-views/src/ToplevelView.cpp
+++ b/src/examples/louvre-views/src/ToplevelView.cpp
@@ -154,10 +154,10 @@ static void onPointerButtonResizeArea(InputRect *rect, void *data, UInt32 button
 
         if (now  - view->lastTopbarClickMs < 300)
         {
-            if (view->toplevel->maximized())
-                view->toplevel->unsetMaximizedRequest();
+            if (toplevel->maximized())
+                toplevel->unsetMaximizedRequest();
             else
-                view->toplevel->setMaximizedRequest();
+                toplevel->setMaximizedRequest();
         }
 
         view->lastTopbarClickMs = now;
@@ -352,7 +352,7 @@ ToplevelView::ToplevelView(Toplevel *toplevel) :
     decoL.insertAfter(children().front());
     decoR.insertAfter(children().front());
     decoBL.insertAfter(children().front());
-    decoBR.insertAfter(children().front());   
+    decoBR.insertAfter(children().front());
     clipTop.insertAfter(children().front());
 }
 

--- a/src/lib/core/LCursor.h
+++ b/src/lib/core/LCursor.h
@@ -131,6 +131,8 @@ public:
 
     /**
      * @brief Assigns an LXCursor.
+     *
+     * @note Passing `nullptr` is a no-op.
      */
     void setCursor(const LXCursor *xcursor) noexcept;
 

--- a/src/lib/core/default/LKeyboardDefault.cpp
+++ b/src/lib/core/default/LKeyboardDefault.cpp
@@ -21,9 +21,11 @@ void LKeyboard::keyEvent(const LKeyboardKeyEvent &event)
 
     sendKeyEvent(event);
 
-    const bool L_CTRL      { isKeyCodePressed(KEY_LEFTCTRL) };
+    const bool L_CTRL      { isKeyCodePressed(KEY_LEFTCTRL)  };
+    const bool R_CTRL      { isKeyCodePressed(KEY_RIGHTCTRL) };
     const bool L_SHIFT     { isKeyCodePressed(KEY_LEFTSHIFT) };
-    const bool mods        { isKeyCodePressed(KEY_LEFTALT) && L_CTRL };
+    const bool L_ALT       { isKeyCodePressed(KEY_LEFTALT)   };
+    const bool mods        { L_ALT || L_SHIFT || L_CTRL || R_CTRL };
     const xkb_keysym_t sym { keySymbol(event.keyCode()) };
 
     if (event.state() == LKeyboardKeyEvent::Released)

--- a/src/lib/core/events/LKeyboardKeyEvent.cpp
+++ b/src/lib/core/events/LKeyboardKeyEvent.cpp
@@ -8,6 +8,17 @@ void LKeyboardKeyEvent::notify()
 {
     LKeyboard::LKeyboardPrivate &keyboard { *seat()->keyboard()->imp() };
 
+    // CTRL + ALT + (F1, F2, ..., F10) : Switch TTY.
+    if (seat()->imp()->libseatHandle
+        && seat()->keyboard()->isKeyCodePressed(KEY_LEFTALT)
+        && keyCode() >= KEY_F1 && keyCode() <= KEY_F10
+        && (seat()->keyboard()->isKeyCodePressed(KEY_LEFTCTRL)
+            || seat()->keyboard()->isKeyCodePressed(KEY_RIGHTCTRL)))
+    {
+        seat()->setTTY(keyCode() - KEY_F1 + 1);
+        return;
+    }
+
     if (keyboard.xkbKeymapState)
     {
         xkb_state_update_key(keyboard.xkbKeymapState,
@@ -44,15 +55,6 @@ void LKeyboardKeyEvent::notify()
         keyboard.pressedKeys.push_back(keyCode());
     else
         LVectorRemoveOneUnordered(keyboard.pressedKeys, keyCode());
-
-
-    // CTRL + ALT + (F1, F2, ..., F10) : Switch TTY.
-    if (seat()->imp()->libseatHandle &&
-        keyCode() >= KEY_F1 && keyCode() <= KEY_F10 &&
-        seat()->keyboard()->isKeyCodePressed(KEY_LEFTCTRL) &&
-        seat()->keyboard()->isKeyCodePressed(KEY_LEFTALT)
-        )
-        seat()->setTTY(keyCode() - KEY_F1 + 1);
 
     if (compositor()->state() == LCompositor::Initialized)
         seat()->keyboard()->keyEvent(*this);

--- a/src/lib/core/roles/LToplevelResizeSession.cpp
+++ b/src/lib/core/roles/LToplevelResizeSession.cpp
@@ -120,7 +120,6 @@ bool LToplevelResizeSession::start(const LEvent &triggeringEvent, LBitset<LEdge>
 
     m_ackTimer.cancel();
     m_lastSerialHandled = false;
-    m_isActive = true;
     m_triggeringEvent.reset(triggeringEvent.copy());
     m_edge = edge;
     m_initSize = m_toplevel->windowGeometry().size();

--- a/src/lib/core/scene/LScene.cpp
+++ b/src/lib/core/scene/LScene.cpp
@@ -393,11 +393,10 @@ retry:
         return;
     }
 
-    // Left button pressed
     if (event.state() == LPointerButtonEvent::Pressed)
     {
         // Keep a ref to continue sending it events after the cursor
-        // leaves, if the left button remains pressed
+        // leaves, if the button remains pressed
         pointer.setDraggingSurface(seat()->pointer()->focus());
 
         if (!keyboard.focus() || !pointer.focus()->isSubchildOf(keyboard.focus()))
@@ -425,7 +424,7 @@ retry:
         else
             pointer.focus()->raise();
     }
-    // Left button released
+    // Button released
     else
     {
         pointer.sendButtonEvent(event);

--- a/src/lib/core/scene/LScene.cpp
+++ b/src/lib/core/scene/LScene.cpp
@@ -393,12 +393,6 @@ retry:
         return;
     }
 
-    if (event.button() != LPointerButtonEvent::Left)
-    {
-        pointer.sendButtonEvent(event);
-        return;
-    }
-
     // Left button pressed
     if (event.state() == LPointerButtonEvent::Pressed)
     {

--- a/src/lib/core/scene/LScene.cpp
+++ b/src/lib/core/scene/LScene.cpp
@@ -879,10 +879,12 @@ retry:
 
     const bool sessionLocked { sessionLockManager()->state() != LSessionLockManager::Unlocked };
     LKeyboard &keyboard { *seat()->keyboard() };
-    const bool L_CTRL      { keyboard .isKeyCodePressed(KEY_LEFTCTRL) };
-    const bool L_SHIFT     { keyboard .isKeyCodePressed(KEY_LEFTSHIFT) };
-    const bool mods        { keyboard .isKeyCodePressed(KEY_LEFTALT) && L_CTRL };
-    const xkb_keysym_t sym { keyboard .keySymbol(event.keyCode()) };
+    const bool L_CTRL      { keyboard.isKeyCodePressed(KEY_LEFTCTRL) };
+    const bool R_CTRL      { keyboard.isKeyCodePressed(KEY_RIGHTCTRL) };
+    const bool L_SHIFT     { keyboard.isKeyCodePressed(KEY_LEFTSHIFT) };
+    const bool L_ALT       { keyboard.isKeyCodePressed(KEY_LEFTALT) };
+    const bool mods        { L_ALT || L_SHIFT || L_CTRL || R_CTRL };
+    const xkb_keysym_t sym { keyboard.keySymbol(event.keyCode()) };
 
     if (event.state() == LKeyboardKeyEvent::Released)
     {


### PR DESCRIPTION
`louvre-views`: As the title mentions, this adds the ability to move/resize windows with SUPER (left META) + click/drag (left button for move, right button for resize).

Other small things:

- Allow right CTRL in Ctrl-Alt-F1 for switching VTs. Also, don't start a Weston-terminal for Ctrl-Alt-F1.
- Toggle maximize with Shift-Super-PageUp. Minimize with Shift-Super-PageDown.