### PR TITLE
Feature: Signal Handler

### DIFF
--- a/src/backends/graphic/Wayland/LGraphicBackendWayland.cpp
+++ b/src/backends/graphic/Wayland/LGraphicBackendWayland.cpp
@@ -515,7 +515,7 @@ public:
 
             wl_display_flush(display);
 
-            poll(shared.fd, 2, -1);
+            poll(shared.fd, 2, output->state() == LOutput::PendingInitialize ? 100 : -1);
 
             if (shared.fd[0].revents & POLLIN)
                 eventfd_read(shared.fd[0].fd, &value);
@@ -982,6 +982,7 @@ public:
     /* OUTPUT */
     static bool outputInitialize(LOutput */*output*/)
     {
+        eventfd_write(shared.fd[0].fd, 1);
         return true;
     }
 

--- a/src/lib/core/LPainter.cpp
+++ b/src/lib/core/LPainter.cpp
@@ -29,12 +29,9 @@ static void makeExternalShader(std::string &shader) noexcept
     }
 }
 
-LPainter::LPainter() noexcept : LPRIVATE_INIT_UNIQUE(LPainter)
+LPainter::LPainter(LOutput *output) noexcept : LPRIVATE_INIT_UNIQUE(LPainter)
 {
     imp()->painter = this;
-
-    compositor()->imp()->threadsMap[std::this_thread::get_id()].painter = this;
-
     imp()->updateExtensions();
     imp()->updateCPUFormats();
 
@@ -313,6 +310,13 @@ LPainter::LPainter() noexcept : LPRIVATE_INIT_UNIQUE(LPainter)
     glDisable(GL_SAMPLE_ALPHA_TO_ONE);
 
     imp()->shaderSetAlpha(1.f);
+
+    if (output)
+    {
+        imp()->output = output;
+        bindProgram();
+        bindFramebuffer(output->framebuffer());
+    }
 }
 
 LPainter::~LPainter() noexcept

--- a/src/lib/core/LPainter.h
+++ b/src/lib/core/LPainter.h
@@ -277,7 +277,7 @@ public:
 
     friend class LCompositor;
     friend class LOutput;
-    LPainter() noexcept;
+    LPainter(LOutput *output = nullptr) noexcept;
     ~LPainter() noexcept;
 };
 

--- a/src/lib/core/default/LCompositorDefault.cpp
+++ b/src/lib/core/default/LCompositorDefault.cpp
@@ -156,6 +156,13 @@ bool LCompositor::globalsFilter(LClient *client, LGlobal *global)
 }
 //! [globalsFilter]
 
+//! [onPosixSignal]
+void LCompositor::onPosixSignal(int signal)
+{
+    LLog::debug("[LCompositor::onPosixSignal] Signal %d handled.", signal);
+}
+//! [onPosixSignal]
+
 //! [initialized]
 void LCompositor::initialized()
 {

--- a/src/lib/core/private/LCompositorPrivate.cpp
+++ b/src/lib/core/private/LCompositorPrivate.cpp
@@ -149,6 +149,8 @@ bool LCompositor::LCompositorPrivate::initWayland()
 
     // Install Signal Handler
     signalSource = wl_event_loop_add_signal(waylandEventLoop, SIGTERM, signalHandler, nullptr);
+    signalSource = wl_event_loop_add_signal(waylandEventLoop, SIGINT, signalHandler, nullptr);
+    signalSource = wl_event_loop_add_signal(waylandEventLoop, SIGKILL, signalHandler, nullptr);
 
     compositor()->imp()->events[LEV_WAYLAND].events = EPOLLIN | EPOLLOUT;
     compositor()->imp()->events[LEV_WAYLAND].data.fd = wl_event_loop_get_fd(waylandEventLoop);

--- a/src/lib/core/private/LCompositorPrivate.cpp
+++ b/src/lib/core/private/LCompositorPrivate.cpp
@@ -147,11 +147,6 @@ bool LCompositor::LCompositorPrivate::initWayland()
     waylandEventLoop = wl_display_get_event_loop(display);
     auxEventLoop = wl_event_loop_create();
 
-    // Install Signal Handler
-    signalSource = wl_event_loop_add_signal(waylandEventLoop, SIGTERM, signalHandler, nullptr);
-    signalSource = wl_event_loop_add_signal(waylandEventLoop, SIGINT, signalHandler, nullptr);
-    signalSource = wl_event_loop_add_signal(waylandEventLoop, SIGKILL, signalHandler, nullptr);
-
     compositor()->imp()->events[LEV_WAYLAND].events = EPOLLIN | EPOLLOUT;
     compositor()->imp()->events[LEV_WAYLAND].data.fd = wl_event_loop_get_fd(waylandEventLoop);
 
@@ -207,11 +202,6 @@ void LCompositor::LCompositorPrivate::unitWayland()
     {
         wl_event_loop_destroy(auxEventLoop);
         auxEventLoop = nullptr;
-    }
-
-    if (signalSource)
-    {
-        wl_event_source_remove(signalSource);
     }
 
     if (display)
@@ -360,7 +350,7 @@ bool LCompositor::LCompositorPrivate::initGraphicBackend()
     if (WL_bind_wayland_display)
         eglBindWaylandDisplayWL(eglDisplay(), display);
 
-    painter = new LPainter();
+    painter.reset(&initThreadData().painter);
     cursor = new LCursor();
     initDRMLeaseGlobals();
     initDMAFeedback();
@@ -474,12 +464,7 @@ void LCompositor::LCompositorPrivate::unitGraphicBackend(bool closeLib)
 {
     unitDMAFeedback();
     unitDRMLeaseGlobals();
-
-    if (painter)
-    {
-        delete painter;
-        painter = nullptr;
-    }
+    unitThreadData();
 
     if (isGraphicBackendInitialized && graphicBackend)
     {
@@ -803,24 +788,31 @@ void LCompositor::LCompositorPrivate::processAnimations()
 
 void LCompositor::LCompositorPrivate::destroyPendingRenderBuffers(std::thread::id *id)
 {
-    std::thread::id threadId = std::this_thread::get_id();
+    std::thread::id threadId { std::this_thread::get_id() };
 
     if (id != nullptr)
         threadId = *id;
 
-    ThreadData &threadData = threadsMap[threadId];
+    auto it { threadsMap.find(threadId) };
 
-    while (!threadData.renderBuffersToDestroy.empty())
+    if (it == threadsMap.end())
+        return;
+
+    while (!it->second.renderBuffersToDestroy.empty())
     {
-        glDeleteFramebuffers(1, &threadData.renderBuffersToDestroy.back().framebufferId);
-        threadData.renderBuffersToDestroy.pop_back();
+        glDeleteFramebuffers(1, &it->second.renderBuffersToDestroy.back().framebufferId);
+        it->second.renderBuffersToDestroy.pop_back();
     }
 }
 
 void LCompositor::LCompositorPrivate::addRenderBufferToDestroy(std::thread::id thread, LRenderBuffer::ThreadData &data)
 {
-    ThreadData &threadData = threadsMap[thread];
-    threadData.renderBuffersToDestroy.push_back(data);
+    auto it { threadsMap.find(thread) };
+
+    if (it == threadsMap.end())
+        return;
+
+    it->second.renderBuffersToDestroy.emplace_back(data);
 }
 
 void LCompositor::LCompositorPrivate::lock()
@@ -846,24 +838,12 @@ void LCompositor::LCompositorPrivate::unlockPoll()
 
 LPainter *LCompositor::LCompositorPrivate::findPainter()
 {
-    LPainter *painter = nullptr;
-    std::thread::id threadId = std::this_thread::get_id();
+    auto it { compositor()->imp()->threadsMap.find(std::this_thread::get_id()) };
 
-    if (threadId == compositor()->mainThreadId())
-        painter = compositor()->imp()->painter;
-    else
-    {
-        for (LOutput *o : compositor()->outputs())
-        {
-            if (o->state() == LOutput::Initialized && o->imp()->threadId == threadId)
-            {
-                painter = o->painter();
-                break;
-            }
-        }
-    }
+    if (it != compositor()->imp()->threadsMap.end())
+        return &it->second.painter;
 
-    return painter;
+    return nullptr;
 }
 
 void LCompositor::LCompositorPrivate::sendPendingConfigurations()
@@ -1055,12 +1035,103 @@ void LCompositor::LCompositorPrivate::unitDRMLeaseGlobals()
             compositor()->removeGlobal(gpu->m_leaseGlobal);
 }
 
-int LCompositor::LCompositorPrivate::signalHandler(int sigNumber, [[maybe_unused]] void* data)
+LCompositor::LCompositorPrivate::ThreadData &LCompositor::LCompositorPrivate::initThreadData(LOutput *output) noexcept
 {
-    LLog::warning("Received signal: %d", sigNumber);
-    if (sigNumber == SIGTERM || sigNumber == SIGINT || sigNumber == SIGKILL)
+    return threadsMap.emplace(std::this_thread::get_id(), output).first->second;
+}
+
+void LCompositor::LCompositorPrivate::unitThreadData() noexcept
+{
+    threadsMap.erase(std::this_thread::get_id());
+}
+
+LCompositor::LCompositorPrivate::ThreadData::ThreadData(LOutput *output) noexcept : output(output), painter(output)
+{
+    LLog::debug("[LCompositorPrivate::ThreadData] Data created for thread %zu.", std::hash<std::thread::id>{}(std::this_thread::get_id()));
+
+    // If not the main thread, disable posix signals right away
+    if (std::this_thread::get_id() != compositor()->mainThreadId())
+        posixSignalsToDisable = compositor()->imp()->posixSignals;
+}
+
+LCompositor::LCompositorPrivate::ThreadData::~ThreadData()
+{
+    LLog::debug("[LCompositorPrivate::ThreadData] Thread %zu data destroyed.", std::hash<std::thread::id>{}(std::this_thread::get_id()));
+}
+
+void LCompositor::LCompositorPrivate::disablePendingPosixSignals() noexcept
+{
+    auto it { threadsMap.find(std::this_thread::get_id()) };
+    if (it == threadsMap.end())
+        return;
+
+    sigset_t sigset;
+
+    while (!it->second.posixSignalsToDisable.empty())
     {
-        compositor()->finish();
+        LLog::debug("[LCompositorPrivate::disablePendingPosixSignals] Posix signal %d blocked in thread %zu.",
+            *it->second.posixSignalsToDisable.begin(),
+            std::hash<std::thread::id>{}(std::this_thread::get_id()));
+        sigemptyset(&sigset);
+        sigaddset(&sigset, *it->second.posixSignalsToDisable.begin());
+        pthread_sigmask(SIG_BLOCK, &sigset, nullptr);
+        it->second.posixSignalsToDisable.erase(it->second.posixSignalsToDisable.begin());
     }
+}
+
+void LCompositor::LCompositorPrivate::unitPosixSignals() noexcept
+{
+    posixSignals.clear();
+    posixSignalsChanged = true;
+    handlePosixSignalChanges();
+}
+
+static int posixSignalHandler(int signal, void *)
+{
+    compositor()->onPosixSignal(signal);
     return 0;
+}
+
+void LCompositor::LCompositorPrivate::handlePosixSignalChanges() noexcept
+{
+    if (!posixSignalsChanged)
+        return;
+
+    posixSignalsChanged = false;
+
+    auto signalsCopy { posixSignals };
+    sigset_t sigset;
+
+    // Handle destroyed signals
+    for (auto sourceIt = posixSignalSources.begin(); sourceIt != posixSignalSources.end();)
+    {
+        // Still alive, nothing to do
+        if (signalsCopy.contains(sourceIt->first))
+        {
+            // Only keep pending-to-add signals
+            signalsCopy.erase(sourceIt->first);
+            sourceIt++;
+        }
+        else // The user removed it
+        {
+            LLog::debug("[LCompositorPrivate::handlePosixSignalChanges] Event source removed for posix signal %d.", sourceIt->first);
+            wl_event_source_remove(sourceIt->second);
+
+            // libwayland doesn't unblock it automatically when removed
+            sigemptyset(&sigset);
+            sigaddset(&sigset, sourceIt->first);
+            pthread_sigmask(SIG_UNBLOCK, &sigset, nullptr);
+
+            sourceIt = posixSignalSources.erase(sourceIt);
+        }
+    }
+
+
+    // Create added signals
+    while (!signalsCopy.empty())
+    {
+        LLog::debug("[LCompositorPrivate::handlePosixSignalChanges] Event source created for posix signal %d.", *signalsCopy.begin());
+        posixSignalSources[*signalsCopy.begin()] = wl_event_loop_add_signal(waylandEventLoop, *signalsCopy.begin(), &posixSignalHandler, nullptr);
+        signalsCopy.erase(signalsCopy.begin());
+    }
 }

--- a/src/lib/core/private/LCompositorPrivate.h
+++ b/src/lib/core/private/LCompositorPrivate.h
@@ -149,6 +149,10 @@ LPRIVATE_CLASS(LCompositor)
     void handleDestroyedClients();
     std::set<LClient*> destroyedClients;
 
+    // Signal Handler
+    wl_event_source* signalSource = nullptr;
+    static int signalHandler(int sigNumber, void* data);
+
 #if LOUVRE_ASSERT_CHECKS == 1
     void assertSurfacesOrder();
 #endif

--- a/src/lib/core/private/LCompositorPrivate.h
+++ b/src/lib/core/private/LCompositorPrivate.h
@@ -4,16 +4,18 @@
 #include <private/LBackendPrivate.h>
 #include <LCompositor.h>
 #include <LOutput.h>
+#include <LPainter.h>
 #include <LInputDevice.h>
 #include <LRenderBuffer.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <sys/epoll.h>
-#include <map>
+#include <unordered_map>
 #include <unistd.h>
 #include <string>
 #include <filesystem>
 #include <set>
+#include <unordered_set>
 
 using namespace Louvre;
 
@@ -64,7 +66,7 @@ LPRIVATE_CLASS(LCompositor)
         void *graphicBackendHandle { nullptr };
         void *graphicBackendData { nullptr };
         LCursor *cursor { nullptr };
-        LPainter *painter { nullptr };
+        LWeak<LPainter> painter;
         LOutput *currentOutput { nullptr };
         void unitDRMLeaseGlobals();
     void unitGraphicBackend(bool closeLib);
@@ -117,14 +119,27 @@ LPRIVATE_CLASS(LCompositor)
     // Thread specific data
     struct ThreadData
     {
-        LPainter *painter { nullptr };
+        ThreadData(LOutput *output) noexcept;
+        ~ThreadData();
+        LWeak<LOutput> output;
+        LPainter painter;
         std::vector<LRenderBuffer::ThreadData> renderBuffersToDestroy;
+        std::unordered_set<int> posixSignalsToDisable;
     };
-
-    std::map<std::thread::id, ThreadData> threadsMap;
+    std::unordered_map<std::thread::id, ThreadData> threadsMap;
+    ThreadData &initThreadData(LOutput *output = nullptr) noexcept;
+    void unitThreadData() noexcept;
     void destroyPendingRenderBuffers(std::thread::id *id);
     void addRenderBufferToDestroy(std::thread::id thread, LRenderBuffer::ThreadData &data);
     static LPainter *findPainter();
+
+    // Posix signals
+    std::unordered_set<int> posixSignals;
+    std::unordered_map<int, wl_event_source*> posixSignalSources;
+    bool posixSignalsChanged { false };
+    void disablePendingPosixSignals() noexcept; // Called from rendering threads
+    void handlePosixSignalChanges() noexcept; // Called from the main thread
+    void unitPosixSignals() noexcept;
 
     void sendPendingConfigurations();
     void sendPresentationTime();
@@ -148,10 +163,6 @@ LPRIVATE_CLASS(LCompositor)
 
     void handleDestroyedClients();
     std::set<LClient*> destroyedClients;
-
-    // Signal Handler
-    wl_event_source* signalSource = nullptr;
-    static int signalHandler(int sigNumber, void* data);
 
 #if LOUVRE_ASSERT_CHECKS == 1
     void assertSurfacesOrder();

--- a/src/lib/core/private/LOutputPrivate.h
+++ b/src/lib/core/private/LOutputPrivate.h
@@ -57,7 +57,7 @@ LPRIVATE_CLASS_NO_COPY(LOutput)
     LOutputPrivate(LOutput *output);
 
     // Created before initializeGL() and destroyed after uninitializeGL()
-    LPainter *painter { nullptr };
+    LWeak<LPainter> painter;
 
     // Using bitset instead of a booleans to save some bytes
     LBitset<StateFlags> stateFlags { FractionalOversamplingEnabled | HwCursorEnabled | CursorEnabled };
@@ -111,6 +111,7 @@ LPRIVATE_CLASS_NO_COPY(LOutput)
     std::vector<Protocols::WlrOutputManagement::RWlrOutputHead*> wlrOutputHeads;
 
     // Thread sync stuff
+    bool initACK { false };
     std::atomic<bool> callLock;
     std::atomic<bool> callLockACK;
     std::thread::id threadId;

--- a/src/lib/core/scene/LSceneView.cpp
+++ b/src/lib/core/scene/LSceneView.cpp
@@ -54,7 +54,7 @@ void LSceneView::addDamage(LOutput *output, const LRegion &damage) noexcept
 
 void LSceneView::render(const LRegion *exclude) noexcept
 {
-    LPainter *painter { compositor()->imp()->threadsMap[std::this_thread::get_id()].painter };
+    LPainter *painter { compositor()->imp()->findPainter() };
 
     if (!painter)
         return;


### PR DESCRIPTION
This is a draft implementation to open a discussion about signal handling on Louvre based compositors.
Eventually, Louvre could provide an API for the user to be able to set the signalHandler externally (otherwise, Louvre would use some default sane implementation).

On the Louvre's user side, this was tried:

```cpp
char* envWaylandDisplay = std::getenv("WAYLAND_DISPLAY");
wl_display* waylandDisplay = wl_display_connect(envWaylandDisplay);
wl_event_loop* waylandEventLoop = wl_display_get_event_loop(waylandDisplay);

signalSource = wl_event_loop_add_signal(waylandEventLoop, SIGTERM, signalHandler, nullptr);
```

However, when sending a signal to the compositor, the `signalHandler` appears to not be called.

After trying a similar approach directly on Louvre, the following result was obtained:

![image](https://github.com/user-attachments/assets/71898e06-ac4a-4976-973d-819c5382c1f9)

And the signal was correctly caught. 

We believe this difference might come from this information: [link](https://wayland.freedesktop.org/docs/html/apc.html#Server-structwl__event__source_1a1706e2490502a95f24ccb59cbae3e2f8)

> It is the caller's responsibility to ensure that all other threads have also blocked the signal.

And by installing the signal handler after the compositor start function, we were unable to block the signal in other threads. However, the signal handler installation uses the `wl_display` created during the compositor start function, making it difficult to install it before running the compositor start.