### PR TITLE
Documentation: arch aur package is not a pre-built binary

### DIFF
--- a/doxygen/md/Downloads.md
+++ b/doxygen/md/Downloads.md
@@ -1,8 +1,8 @@
 # 📦 Downloads {#downloads_page}
 
-## Pre-built Binaries
+## Packages
 
-Pre-built binaries are provided for the following distributions. Please be aware that their versions may not always match the latest Louvre release.
+Pre-built binaries and packages are provided for the following distributions. Please be aware that their versions may not always match the latest Louvre release.
 
 * **Arch** : [louvre](https://aur.archlinux.org/packages/louvre) - *Thanks to [@TrialnError](https://aur.archlinux.org/account/TrialnError)*.
 * **Fedora** : [cuarzo-louvre](https://copr.fedorainfracloud.org/coprs/cuarzo/software/) - *By [Cuarzo Software](https://github.com/CuarzoSoftware) (always up to date)*.


### PR DESCRIPTION
Hi @ehopperdietzel ,

This is a small nit pick. The `archlinux` AUR package specified in the documentation does not provide a pre-built binary, as users still need to build the package locally.

Let me know if you want me to write it in any other way :)